### PR TITLE
Remove the "self injection" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ changeA$.inject(interaction$);
 changeB$.inject(interaction$);
 ```
 
-Seems easy for now, but when streams number grows, amount of boilerplate will grow proportionally. With `createStreamsGroup` you can achieve the same effect in more compact way and create batch of streams from plain functions. Each stream in group has access to other streams in the same group, as well as to streams from groups injected by `inject` method of the group. Automatic injection function bases on names of function parameters and keys of group object.
+Seems easy for now, but when streams number grows, amount of boilerplate will grow proportionally. With `createStreamsGroup` you can achieve the same effect in more compact way and create batch of streams from plain functions. Each stream in the group will be injected input streams given by the `inject` method of the group, where this connection is detected based on names of function parameters and keys of the group object.
 
 ```javascript
 import { createStream, render, h, Rx } from 'cyclejs';


### PR DESCRIPTION
In this PR I'm suggesting to remove the actual feature of "self injection" where a stream in a group can view other streams in the same group. I think that's too much magic for the developer, and self injecting manually, like `model.inject(model)`, isn't more boilerplate, just brings clarity.
